### PR TITLE
Docker env for ac

### DIFF
--- a/.ac_env_db.sample
+++ b/.ac_env_db.sample
@@ -1,0 +1,2 @@
+MYSQL_ROOT_PASSWORD=admin123
+MYSQL_DATABASE=access_control_test

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ pkg/*
 .bundle
 *.gem
 *.swp
+.ac_env_db
 Session.vim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:2.4.6-alpine3.9
+
+ENV APP_ROOT /app
+
+# - build-essential: To ensure certain gems can be compiled
+# - nodejs: Compile assets
+# - libmariadbd-dev: MariaDB development files
+
+RUN mkdir -p $APP_ROOT
+WORKDIR $APP_ROOT
+
+RUN apk add --no-cache --update build-base \
+                                linux-headers \
+                                bash \
+                                less \
+                                git \
+                                mariadb \
+                                mariadb-dev \
+                                mariadb-client \
+                                sqlite-dev \
+                                sqlite
+
+COPY . .
+
+RUN bundle install --binstubs

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,4 @@
+FROM mariadb:10.6-focal
+
+RUN echo "[mysqld]" >> /etc/mysql/conf.d/sql_mode.cnf
+RUN echo "sql_mode = NO_ENGINE_SUBSTITUTION,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER" >> /etc/mysql/conf.d/sql_mode.cnf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  access-control:
+    build: .
+    image: moltrio-insurance:dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: "3"
 
+networks:
+  jungle:
+    external: true
+
 services:
   access-control:
     build: .
-    image: moltrio-insurance:dev
+    networks:
+      - jungle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,29 @@
 version: "3"
 
 networks:
-  jungle:
+  ac-net:
     external: true
+
+volumes:
+  mariadb-access-control:
 
 services:
   access-control:
     build: .
+    depends_on:
+      - access-control-db
     networks:
-      - jungle
+      - ac-net
+
+  access-control-db:
+    build:
+      context: .
+      dockerfile: Dockerfile.db
+    image: moltrio-mariadb:10.6-focal
+    env_file:
+      - .ac_env_db
+    volumes:
+      - mariadb-access-control:/var/lib/mysql
+    networks:
+      - ac-net
+

--- a/lib/access_control/api.rb
+++ b/lib/access_control/api.rb
@@ -9,7 +9,6 @@ require 'access_control/method_protection'
 require 'access_control/active_record_association'
 
 module AccessControl
-
   MANAGER_THREAD_KEY = :ac_manager
 
   def self.manager

--- a/lib/access_control/configuration.rb
+++ b/lib/access_control/configuration.rb
@@ -3,9 +3,7 @@ require 'access_control/util'
 require 'access_control/registry'
 
 module AccessControl
-
   class Configuration
-
     attr_reader :default_roles
 
     def initialize
@@ -61,5 +59,4 @@ module AccessControl
   def self.config
     @config ||= Configuration.new
   end
-
 end

--- a/lib/access_control/manager.rb
+++ b/lib/access_control/manager.rb
@@ -3,9 +3,7 @@ require 'access_control/principal'
 require 'access_control/permission_inspector'
 
 module AccessControl
-
   class Manager
-
     def initialize
       @restrict_queries = true
       @use_anonymous = false

--- a/lib/access_control/node.rb
+++ b/lib/access_control/node.rb
@@ -3,7 +3,6 @@ require 'access_control/persistable'
 require 'access_control/node_manager'
 
 module AccessControl
-
   def AccessControl.Node(object)
     if object.kind_of?(AccessControl::Node)
       object

--- a/lib/access_control/node/class_methods.rb
+++ b/lib/access_control/node/class_methods.rb
@@ -7,7 +7,6 @@ require 'access_control/orm'
 
 module AccessControl
   module Node::ClassMethods
-
     def persistent_model
       @persistent_model ||= ORM.adapt_class(Node::Persistent)
     end

--- a/lib/access_control/node_manager.rb
+++ b/lib/access_control/node_manager.rb
@@ -1,6 +1,5 @@
 module AccessControl
   class NodeManager
-
     class << self
       def refresh_parents_of(node)
         new(node).refresh_parents

--- a/lib/access_control/registry_factory.rb
+++ b/lib/access_control/registry_factory.rb
@@ -4,7 +4,6 @@ require 'backports'
 
 module AccessControl
   class RegistryFactory
-
     def initialize(permission_factory = Permission.public_method(:new))
       @permission_factory = permission_factory
     end

--- a/lib/access_control/role.rb
+++ b/lib/access_control/role.rb
@@ -3,7 +3,6 @@ require 'access_control/orm'
 
 module AccessControl
   class Role
-
     class AssignmentsAssociation# {{{
       attr_reader :owner, :volatile
 

--- a/lib/access_control/role/persistent.rb
+++ b/lib/access_control/role/persistent.rb
@@ -4,7 +4,6 @@ require 'access_control/dataset_helper'
 module AccessControl
   class Role
     class Persistent < Sequel::Model(:ac_roles)
-
       include AccessControl::DatasetHelper
 
       def self.create!(properties={})


### PR DESCRIPTION
A simple Docker environment for access control that includes docker compose. This creates a container for ac (that does not stay up since it's unnecessary) and a MariaDB container where ac can run its tests.